### PR TITLE
fix img thumbnail at create

### DIFF
--- a/Controller/NewsAdvancedController.php
+++ b/Controller/NewsAdvancedController.php
@@ -257,7 +257,7 @@ class NewsAdvancedController extends AppController {
 						'updated' => date('Y-m-d H:i:s'),
 						'comments' => 0,
 						'likes' => 0,
-						'img' => $this->request->data['title'],
+						'img' => $this->request->data['img'],
 						'slug' => Inflector::slug($this->request->data['slug'], '-'),
 						'published' => $this->request->data['published']
 					));


### PR DESCRIPTION
Quand on créer une news le plugin ajoute le title dans la colonne img au lieu de l'img. GNÉÉÉÉÉÉ

Ce serait cool de vérifier un minimum les plugins avant de les ajouter nan ?